### PR TITLE
Change spending distribution to spending inclination

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ value is used.
   person will spend each month. For example, setting this to 50% means that
   people will, on average, spend 50% of their money each month. The actual
   percentage that each person spends is different each month, drawn uniformly
-  from the largest range between 0 and 1 whose center is at this number.
+  from a range between 0 and 1, squashed on one end so that it centers at this
+  number.
 - **Industry distribution**: the distribution of how likely a person is to spend
   money in a particular industry. So for example, if you had 5 industries, 4
   that each have 25% probability, and 1 with 0%, this would simulate the effect

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ see what happens to the distribution of wealth across people and companies, the
 the unemployment rate, and the business closure rate, when you vary certain
 parameters.
 
+> Note that this is merely an experimental model of a toy economy. I do not
+claim that this is an accurate model of reality, and any results derived from
+this model should not be used to conclude what would actually happen in reality.
+I only use it to understand the potential effects of certain parameters on a
+simplified model.
+
 This README covers how the simulation is designed and how to run it. For
 development details, see the [developer guide](docs/dev_guide.md).
 
@@ -103,15 +109,11 @@ value is used.
   monthly payroll.
 - **Rehire rate**: the probability that an unemployed person is rehired when an
   opening comes up.
-- **Spending distribution**: the distribution of people's spending rates. Each
-  month, every person picks a spending rate (a fraction of their money) from
-  this distribution, and spends that much in that month. Each value should be
-  a pair of numbers representing a *range* of rates people can choose from
-  (e.g. 0 to 1 would be the full range of their money). People pick a range
-  according to the distribution, and then choose a value uniformly within that
-  range. So for example, if you had two ranges [0, 0.5] with 25% probability,
-  and [0.5, 1] with 75% probability, this would be a "skewed" distribution that
-  gives people a tendency to spend more.
+- **Inclination to spend**: the average percentage of their money that each
+  person will spend each month. For example, setting this to 50% means that
+  people will, on average, spend 50% of their money each month. The actual
+  percentage that each person spends is different each month, drawn uniformly
+  from the largest range between 0 and 1 whose center is at this number.
 - **Industry distribution**: the distribution of how likely a person is to spend
   money in a particular industry. So for example, if you had 5 industries, 4
   that each have 25% probability, and 1 with 0%, this would simulate the effect

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -96,16 +96,7 @@ Periods:
   - `person_stimulus` (float)
   - `company_stimulus` (float)
   - `rehire_rate` (float)
-  - `spending` (distribution). As another example, a uniform distribution over
-    [0, 1] would be represented as:
-
-    ```json
-    [
-      [[0, 1]],
-      [1]
-    ]
-    ```
-
+  - `spending_inclination` (float)
   - `industries` (distribution)
 
 Example:
@@ -127,10 +118,7 @@ Example:
       "person_stimulus": 1.0,
       "company_stimulus": 1.0,
       "rehire_rate": 1.0,
-      "spending": [
-        [[0, 0.5], [0.5, 1]],
-        [0.25, 0.75]
-      ],
+      "spending_inclination": 0.5,
       "industries": [
         ["industry 1", "industry 2"],
         [0.5, 0.5]

--- a/simulator/test.py
+++ b/simulator/test.py
@@ -53,27 +53,23 @@ def test_init_income_distribution():
     return
   print('Passed')
 
-def test_init_spending_distribution():
-  print('Check that spending rates are allocated according to the distribution')
-  range1 = [0, 0.25]
-  range2 = [0.25, 1]
-  p = 0.5
+def test_init_spending_inclination(s):
+  print('Check that spending rates are allocated according to the spending inclination: %.2f' % (s))
   people, _ = simulator.init(
     ncompanies=1,
-    spending=[[range1, range2], [p, p]],
+    spending_inclination=s,
     company_size=[[1000], [1]]
   )
 
-  nrange1 = len([p for p in people if range1[0] <= p.spending_rate < range1[1]])
-  nrange2 = len([p for p in people if range2[0] <= p.spending_rate < range2[1]])
-  tolerance = 0.04
-  lower_bound = len(people) * (p - tolerance)
-  upper_bound = len(people) * (p + tolerance)
+  avg = sum([p.spending_rate for p in people]) / len(people)
+  tolerance = 0.01
+  lower_bound = s - tolerance
+  upper_bound = s + tolerance
 
-  if not (lower_bound <= nrange1 <= upper_bound and lower_bound <= nrange2 <= upper_bound):
-    print('Failed: spending rate distribution is off')
-    print('Expected: npeople in each category in [%d, %d]' % (int(lower_bound), int(upper_bound)))
-    print('Actual:   nrange1=%d, nrange2=%d' % (nrange1, nrange2))
+  if not (lower_bound <= avg <= upper_bound):
+    print('Failed: spending inclination is off')
+    print('Expected: average spending rate in range [%.4f, %.4f]' % (lower_bound, upper_bound))
+    print('Actual:   average spending rate = %.4f' % (avg))
     return
   print('Passed')
 
@@ -394,7 +390,9 @@ def test_rehire():
 def main():
   test_init_company_size()
   test_init_income_distribution()
-  test_init_spending_distribution()
+  test_init_spending_inclination(0.5)
+  test_init_spending_inclination(0.2)
+  test_init_spending_inclination(0.9)
   test_init_industries()
   test_stimulus()
   test_people_spending1()

--- a/web_app/index.js
+++ b/web_app/index.js
@@ -71,6 +71,60 @@ $(document).ready(() => {
     }
   }
 
+  // An input for a percentage, given its display name and default value.
+  class PercentageInput {
+    constructor(displayName, defaultValue) {
+      this.value = defaultValue;
+      this.element = null;
+
+      let label = element("h4").addClass("card-title")
+        .text(displayName);
+
+      let inputLabel = element("span")
+        .text(this.probStr(100 * this.value));
+      let input = element("input")
+        .addClass("form-control-range")
+        .attr("type", "range")
+        .attr("value", this.value.toString())
+        .on("input", (e) => {
+          // Track the value
+          this.value = e.currentTarget.valueAsNumber / 100;
+
+          // Update the text label
+          inputLabel.text(this.probStr(e.currentTarget.value));
+        });
+
+      this.element = withPadding(
+        element("div").addClass("card")
+        .append(element("div").addClass("card-body")
+          .append(label)
+          .append(input)
+          .append(inputLabel)
+        )
+      );
+    }
+
+    // Returns the probability string, given the value out of 100
+    probStr(v) {
+      return v.toString() + "%";
+    }
+
+    // Sets the value
+    set(v) {
+      if (v == null || v == undefined) {
+        return false;
+      }
+
+      this.value = v;
+      let p = 100 * this.value;
+      let input = this.element.find("input")[0];
+      let label = this.element.find("span");
+      input.value = p;
+      label.text(this.probStr(p));
+      return true;
+    }
+  }
+
   // An input for one (value, probability) pair in a distribution, given
   // its name
   class DistributionInput {
@@ -349,7 +403,7 @@ $(document).ready(() => {
       this.personStimulus = new Var("person_stimulus", new NumberInput("float", "Person stimulus", 0));
       this.companyStimulus = new Var("company_stimulus", new NumberInput("float", "Company stimulus", 0));
       this.rehireRate = new Var("rehire_rate", new NumberInput("float", "Rehire rate", 0));
-      this.spendingInclination = new Var("spending_inclination", new NumberInput("float", "Inclination to spend", 0));
+      this.spendingInclination = new Var("spending_inclination", new PercentageInput("Inclination to spend", 0));
       this.industries = new Var("industries", new DistributionInputs("string", "Industry distribution"));
 
       this.element = withPadding(

--- a/web_app/index.js
+++ b/web_app/index.js
@@ -349,7 +349,7 @@ $(document).ready(() => {
       this.personStimulus = new Var("person_stimulus", new NumberInput("float", "Person stimulus", 0));
       this.companyStimulus = new Var("company_stimulus", new NumberInput("float", "Company stimulus", 0));
       this.rehireRate = new Var("rehire_rate", new NumberInput("float", "Rehire rate", 0));
-      this.spending = new Var("spending", new DistributionInputs("range", "Spending distribution"));
+      this.spendingInclination = new Var("spending_inclination", new NumberInput("float", "Inclination to spend", 0));
       this.industries = new Var("industries", new DistributionInputs("string", "Industry distribution"));
 
       this.element = withPadding(
@@ -360,22 +360,10 @@ $(document).ready(() => {
           .append(this.personStimulus.input.element)
           .append(this.companyStimulus.input.element)
           .append(this.rehireRate.input.element)
-          .append(this.spending.input.element)
+          .append(this.spendingInclination.input.element)
           .append(this.industries.input.element)
         )
       );
-    }
-
-    // Sets the value from a JSON object. Returns true/false if successful
-    fromJSON(json) {
-      let success = true;
-      success &= this.duration.set(json.duration);
-      success &= this.personStimulus.set(json.person_stimulus);
-      success &= this.companyStimulus.set(json.company_stimulus);
-      success &= this.rehireRate.set(json.rehire_rate);
-      success &= this.spending.set(json.spending);
-      success &= this.industries.set(json.industries);
-      return success;
     }
   }
 
@@ -468,10 +456,7 @@ $(document).ready(() => {
           person_stimulus: p.personStimulus.input.value,
           company_stimulus: p.companyStimulus.input.value,
           rehire_rate: p.rehireRate.input.value,
-          spending: [
-            p.spending.input.values,
-            p.spending.input.probabilities
-          ],
+          spending_inclination: p.spendingInclination.input.value,
           industries: [
             p.industries.input.values,
             p.industries.input.probabilities
@@ -500,9 +485,17 @@ $(document).ready(() => {
       }
 
       for (let i = 0; i < this.periods.length; i++) {
-        success &= this.periods[i].fromJSON(json.periods[i]);
+        success &= this.periods[i].duration.set(json.periods[i].duration);
+        success &= this.periods[i].personStimulus.set(json.periods[i].person_stimulus);
+        success &= this.periods[i].companyStimulus.set(json.periods[i].company_stimulus);
+        success &= this.periods[i].rehireRate.set(json.periods[i].rehire_rate);
+        success &= this.periods[i].spendingInclination.set(json.periods[i].spending_inclination);
+        success &= this.periods[i].industries.set(json.periods[i].industries);
       }
-      return success;
+
+      if (!success) {
+        throw Error("failed to parse config");
+      }
     }
   }
 


### PR DESCRIPTION
Modeling spending using the spending distribution was kind of convoluted. I wanted to simplify how spending is parametrized, and I came up with this new approach instead.

The goal was to use a single value to control people's tendency to spend vs save, but without fixing the rate. The model is not very useful when everyone picks the same spending rate, since everyone builds/loses wealth in unison, so I also wanted variability. So now people still pick a spending rate uniformly between 0 and 1, and users can set one value, the "spending inclination", which controls how much the distribution is skewed toward 0 or 1. A more concise/accurate description of this is in the README.