### PR TITLE
Revert nonpayroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ various metrics about the economy.
 The basic model works like this. There are two kinds of entities: *people* and
 *companies*. Each person works for a company, and receives a paycheck from it
 each month. They spend a portion of their money at different companies during
-the course of each month, saving anything they have leftover. Companies have two
-kinds of expenses: payroll (paychecks to their employees) and nonpayroll
-(expenses paid to other companies, e.g. for goods & services, paid daily).
-Companies lay off employees when they can no longer afford to pay them, hire new
-ones if they can afford to, and go out of business when they have no more
-employees. Each company also belongs to an industry, and we can tweak the amount
+the course of each month, saving anything they have leftover. Companies have
+to pay their expenses every month (in this model, the only expense is payroll).
+They lay off employees when they can't afford their expenses, hire new ones if
+they can afford to, and go out of business when they can no longer afford their
+expenses. Each company also belongs to an industry, and we can tweak the amount
 people spend in each industry. We run this system for a fixed period of time.
 People and companies may build wealth, scrape by, or collapse, according to this
 probabilistic model.
@@ -61,24 +60,21 @@ Initialization:
 - Each person is assigned income and an initial spending rate for the first
   month, both from a distribution
 - Both people and companies get a specified number of months' worth of money
-  (income for people, total expenses for companies)
+  (income for people, payroll expenses for companies)
 
 Each day:
 
 - Each person picks an industry to spend in from a distribution, and picks a
   random company within that industry. They spend 1/30 of their monthly
-  spending to that company (this model has 30 days per month)
-- Each company picks another random company and pays 1/30 of their monthly
-  non-payroll expenses to that company. If they don't have enough money to cover
-  the expense, they pick a random person to lay off until they do. If they run
-  out of employees, they go out of business (removed from the economy).
+  spending to that company (this model has 30 days per month).
 
 At the end of each month:
 
 - Companies rehire unemployed people if they can afford them, and pay their
   employees 1 month's income (similarly laying off employees if they can't
   afford the expenses). People pick a new spending rate for the next month, and
-  receive stimulus grants and/or unemployment benefits if applicable.
+  receive stimulus grants and/or unemployment benefits if applicable. Companies
+  also receive stimulus if applicable.
 
 ## Running a simulation
 
@@ -101,11 +97,7 @@ parameters, which apply for the entire simulation:
   month.
 - **Company size**: a distribution of companies' size (the number of employees
   they have). For example, you could say that 1/3 of companies have 100
-  employees, and 1/3 have 1,000, and 1/3 have 10,000. The size of the company
-  and the income levels of their employees determine their payroll expenses.
-- **Company non-payroll expenses**: the percentage of each company's monthly
-  expenses contributed by non-payroll expenses. This allows you to specify how
-  much additional expense companies have aside from paying their employees.
+  employees, and 1/3 have 1,000, and 1/3 have 10,000.
 
 Then you specify a number of *periods* - a limited duration for which certain
 parameters apply. The periods run in the order listed, and each has the

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ The basic model works like this. There are two kinds of entities: *people* and
 each month. They spend a portion of their money at different companies during
 the course of each month, saving anything they have leftover. Companies have
 to pay their expenses every month (in this model, the only expense is payroll).
-They lay off employees when they can't afford their expenses, hire new ones if
-they can afford to, and go out of business when they can no longer afford their
-expenses. Each company also belongs to an industry, and we can tweak the amount
-people spend in each industry. We run this system for a fixed period of time.
-People and companies may build wealth, scrape by, or collapse, according to this
-probabilistic model.
+They lay off some employees when they can't afford their expenses, going out of
+business when they can no longer afford to pay any employees at all. On the other
+hand, they hire new employees when they can afford to. Each company also belongs
+to an industry, and we can tweak the amount people spend in each industry. We run
+this system for a fixed period of time. People and companies may build wealth,
+scrape by, or collapse, according to this probabilistic model.
 
 We're primarily interested in two things:
 
@@ -71,10 +71,11 @@ Each day:
 At the end of each month:
 
 - Companies rehire unemployed people if they can afford them, and pay their
-  employees 1 month's income (similarly laying off employees if they can't
-  afford the expenses). People pick a new spending rate for the next month, and
-  receive stimulus grants and/or unemployment benefits if applicable. Companies
-  also receive stimulus if applicable.
+  employees 1 month's income. If they can't afford payroll, they pick random
+  employees to lay off until they can. They also receive a stimulus if
+  applicable.
+- People pick a new spending rate for the next month, and receive stimulus
+  grants and/or unemployment benefits if applicable.
 
 ## Running a simulation
 
@@ -120,8 +121,8 @@ value is used.
   person will spend each month. For example, setting this to 50% means that
   people will, on average, spend 50% of their money each month. The actual
   percentage that each person spends is different each month, drawn uniformly
-  from a range between 0 and 1, squashed on one end so that it centers at this
-  number.
+  from a subrange between 0 and 1, pushed toward one end so that it centers at
+  this number.
 - **Spending distribution across industries**: the distribution of which
   industries people will spend their money in. For example, if you had 5
   industries, 4 that each have 25% probability, and 1 with 0%, this would

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -88,7 +88,6 @@ Base parameters:
 - `ncompanies` (int)
 - `income` (distribution)
 - `company_size` (distribution)
-- `nonpayroll` (float)
 
 Periods:
 
@@ -114,7 +113,6 @@ Example:
     [10, 20],
     [0.5, 0.5]
   ],
-  "nonpayroll": 0.75,
   "periods": [
     {
       "duration": 360,

--- a/web_app/index.js
+++ b/web_app/index.js
@@ -21,7 +21,6 @@ $(document).ready(() => {
       [10],
       [1]
     ],
-    nonpayroll: 0.75,
     periods: [{
       duration: 360,
       person_stimulus: 1,
@@ -463,7 +462,6 @@ $(document).ready(() => {
       this.ncompanies = new Var("ncompanies", new NumberInput("Number of companies", "integer"));
       this.income = new Var("income", new DistributionInput("Income levels", "integer"));
       this.company_size = new Var("company_size", new DistributionInput("Company size", "integer"));
-      this.nonpayroll = new Var("nonpayroll", new PercentageInput("Company non-payroll expenses"));
       this.periods = [];
 
       let periodButtons = new AddRemoveButtons(
@@ -483,8 +481,7 @@ $(document).ready(() => {
       [
         this.ncompanies,
         this.income,
-        this.company_size,
-        this.nonpayroll
+        this.company_size
       ].forEach((x) => {
         baseParamsCards.add(x.input.element);
       });
@@ -521,7 +518,6 @@ $(document).ready(() => {
           this.company_size.input.values,
           this.company_size.input.probabilities
         ],
-        nonpayroll: this.nonpayroll.input.value,
         periods: []
       };
 
@@ -550,7 +546,6 @@ $(document).ready(() => {
       success &= this.ncompanies.set(json.ncompanies);
       success &= this.income.set(json.income);
       success &= this.company_size.set(json.company_size);
-      success &= this.nonpayroll.set(json.nonpayroll);
 
       // Add/remove periods if necessary to match the given set
       let diff = Math.abs(json.periods.length - this.periods.length);


### PR DESCRIPTION
After experimenting with non-payroll expenses, I decided to get rid of them.

The way it was designed, it ultimately didn't substantially change the outcome. Since non-payroll expenses changed proportionally with the number of employees, this effectively scaled up a company's expenses by a constant factor. At the same time, all companies roughly net 0 each month by paying out to other companies about the same amount they take in. So the core role that companies have in the outcome -- deciding when to lay off / rehire employees -- which was based on how much money they have relative to their expenses, was largely unchanged, no matter how much non-payroll expense they had.

Since I'm ultimately interested in modeling a shutdown and government stimulus, I'm judging that having only one type of expense (payroll) should give us enough to work with.