### PR TITLE
Fix spending

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ following parameters. All parameters must be set in the first period, but after
 that, if a parameter is not set in a particular period, the previous
 value is used.
 
-- **Duration**: the duration of the period, in days
+- **Duration**: the duration of the period, in months
 - **Stimulus/tax for people**: the fraction of each person's monthly income that's
   granted to them as "stimulus" for this period. In the first period, this is
   the amount of money people will start the simulation with (e.g. 1 month's

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -115,7 +115,7 @@ Example:
   ],
   "periods": [
     {
-      "duration": 360,
+      "duration": 12,
       "person_stimulus": 1.0,
       "company_stimulus": 1.0,
       "unemployment_benefit": 0.8,

--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -35,11 +35,11 @@ defaults = {
 # A person in the model
 class Person:
 
-  def __init__(self, money=0, income=0, employed=True, spending_rate=0, industry='economy'):
+  def __init__(self, money=0, income=0, employed=True, daily_spending=0, industry='economy'):
     self.money = money
     self.income = income # income *per month* (not annual)
     self.employed = employed
-    self.spending_rate = spending_rate
+    self.daily_spending = daily_spending # amount to spend each day this month
     self.industry = industry
 
   def __str__(self):
@@ -72,7 +72,8 @@ def reset_spending_rates(people, spending_inclination):
     hi += 2 * diff # remember diff is negative
   rands = np.random.rand(len(people)) # random numbers used to pick a spending rate for each person
   for i in range(len(people)):
-    people[i].spending_rate = lo + rands[i] * (hi - lo)
+    rate = lo + rands[i] * (hi - lo)
+    people[i].daily_spending = rate * people[i].money / days_per_month
   return people
 
 # Initializes the simulator. Returns the list of people and companies
@@ -80,7 +81,6 @@ def init(
   ncompanies=defaults['ncompanies'],
   income=defaults['income'],
   company_size=defaults['company_size'],
-  spending_inclination=defaults['periods'][0]['spending_inclination'],
   industry_names=defaults['periods'][0]['spending_distribution'][0]
   ):
 
@@ -92,11 +92,10 @@ def init(
     companies[i].employees = [Person(industry=companies[i].industry) for j in range(size[i])]
     people += companies[i].employees
 
-  # Assign each person income and spending rates
+  # Assign each person income
   incomes = np.random.choice(income[0], p=income[1], size=len(people))
   for i in range(len(people)):
     people[i].income = incomes[i] / months_per_year
-  people = reset_spending_rates(people, spending_inclination)
   return people, companies
 
 # Grant stimulus for people and companies. Returns the new list of people and
@@ -131,9 +130,8 @@ def spend(people, companies, spending_distribution, industries):
     for p, rand_ind, r in zip(people, rand_inds, rands):
       ind = industries[rand_ind]
       c = ind[int(r * len(ind))]
-      amount = p.spending_rate * p.money / days_per_month
-      p.money -= amount
-      c.money += amount
+      p.money -= p.daily_spending
+      c.money += p.daily_spending
   return people, companies
 
 # Given the list of people and companies and the probability of rehiring,
@@ -230,7 +228,6 @@ def run(config, on_day=lambda period, day, people, companies: None):
     ncompanies=config['ncompanies'],
     income=config['income'],
     company_size=config['company_size'],
-    spending_inclination=config['periods'][0]['spending_inclination'],
     industry_names=industry_names
   )
   person_stimulus = None
@@ -252,6 +249,7 @@ def run(config, on_day=lambda period, day, people, companies: None):
 
     # Grant stimulus/unemployment benefits for this period
     people, companies = grant_stimulus(people, companies, person_stimulus, company_stimulus)
+    people = reset_spending_rates(people, spending_inclination)
 
     # Run the period
     for j in range(config['periods'][i]['duration']):

--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -18,7 +18,7 @@ defaults = {
   ],
   'periods': [
     {
-      'duration': 360,
+      'duration': 12,
       'person_stimulus': 1,
       'company_stimulus': 1,
       'unemployment_benefit': 0,
@@ -255,23 +255,24 @@ def run(config, on_day=lambda period, day, people, companies: None):
 
     # Run the period
     for j in range(config['periods'][i]['duration']):
-      on_day(i, j, people, companies)
+      for d in range(days_per_month):
+        on_day(i, d, people, companies)
 
-      industries = {
-        ind: [c for c in companies if c.in_business and c.industry == ind]
-        for ind in spending_distribution[0]
-      }
-      people, companies = spend(people, companies, spending_distribution, industries)
+        industries = {
+          ind: [c for c in companies if c.in_business and c.industry == ind]
+          for ind in spending_distribution[0]
+        }
+        people, companies = spend(people, companies, spending_distribution, industries)
 
-      # At the end of the month, companies hire new employees and pay their
-      # employees
-      if j % days_per_month == days_per_month - 1:
-        people, companies = rehire_people(people, companies, rehire_rate)
-        people, companies = layoff_employees(people, companies)
-        people, companies = pay_employees(people, companies)
+        # At the end of the month, companies hire new employees and pay their
+        # employees
+        if d % days_per_month == days_per_month - 1:
+          people, companies = rehire_people(people, companies, rehire_rate)
+          people, companies = layoff_employees(people, companies)
+          people, companies = pay_employees(people, companies)
 
-        # Grant unemployment benefits
-        people = grant_unemployment(people, unemployment_benefit)
+          # Grant unemployment benefits
+          people = grant_unemployment(people, unemployment_benefit)
 
-        # Reset people's spending rates
-        people = reset_spending_rates(people, spending_inclination)
+          # Reset people's spending rates
+          people = reset_spending_rates(people, spending_inclination)

--- a/simulator/test.py
+++ b/simulator/test.py
@@ -159,19 +159,25 @@ def test_people_spending1():
   c1 = simulator.Company(money=c_money, industry=ind)
   c2 = simulator.Company(money=c_money, industry=ind)
   companies = [c1, c2]
-  people, companies = simulator.spend(
-    people=[p],
-    companies=companies,
-    spending_distribution=[[ind], [1]],
-    industries={ind: companies}
-  )
+  people = [p]
+  ndays = 2
+  for i in range(ndays):
+    people, companies = simulator.spend(
+      people=[p],
+      companies=companies,
+      spending_distribution=[[ind], [1]],
+      industries={ind: companies}
+    )
 
-  p_money_exp = p_money - daily_spending
-  c_money_exp = c_money + daily_spending
-  if not (people[0].money == p_money_exp and (companies[0].money == c_money_exp
-    or companies[1].money == c_money_exp)):
+  p_money_exp = p_money - daily_spending * ndays
+  outcomes = [
+    (c_money + ndays * daily_spending, c_money),
+    (c_money, c_money + ndays * daily_spending),
+    (c_money + daily_spending, c_money + daily_spending)
+  ]
+  if not (people[0].money == p_money_exp and (companies[0].money, companies[1].money) in outcomes):
     print('Failed: money was not spent correctly')
-    print('Expected: p.money = %.2f, c1.money or c2.money = %.2f' % (p_money_exp, c_money_exp))
+    print('Expected: p.money = %.2f, (c1.money, c2.money) in %s' % (p_money_exp, outcomes))
     print('Actual:   p.money = %.2f, c1.money = %.2f, c2.money = %.2f' % (
       people[0].money, companies[0].money, companies[1].money
     ))

--- a/web_app/index.js
+++ b/web_app/index.js
@@ -22,7 +22,7 @@ $(document).ready(() => {
       [1]
     ],
     periods: [{
-      duration: 360,
+      duration: 12,
       person_stimulus: 1,
       company_stimulus: 1,
       unemployment_benefit: 0.8,
@@ -431,7 +431,7 @@ $(document).ready(() => {
   class Period {
     // index = index of this period (for display)
     constructor(index) {
-      this.duration = new Var("duration", new NumberInput("Number of days", "integer"));
+      this.duration = new Var("duration", new NumberInput("Duration (months)", "integer"));
       this.person_stimulus = new Var("person_stimulus", new NumberInput("Person stimulus or tax", "float"));
       this.company_stimulus = new Var("company_stimulus", new NumberInput("Company stimulus or tax", "float"));
       this.unemployment_benefit = new Var("unemployment_benefit", new NumberInput("Unemployment benefit", "float"))

--- a/web_app/server.py
+++ b/web_app/server.py
@@ -67,13 +67,13 @@ def run_simulator(ws):
   # Helper functions
   def people_results(people, percentiles):
     return {
-      'person_money': list(np.percentile([p.money for p in people], percentiles)),
+      'person_money': list(np.round(np.percentile([p.money for p in people], percentiles), 2)),
       'person_unemployment': [np.mean([not p.employed for p in people])]
     }
 
   def company_results(companies, percentiles):
     return {
-      'company_money': list(np.percentile([c.money for c in companies], percentiles)),
+      'company_money': list(np.round(np.percentile([c.money for c in companies], percentiles), 2)),
       'company_closures': [np.mean([not c.in_business for c in companies])]
     }
 


### PR DESCRIPTION
Each person is supposed to pick a fraction of their money to spend each month, and spend that fixed amount. But the actual amount calculated each day was a fraction of their *current* money. So when we subtract that amount, the next day, the amount is a fraction of *what's left*. This actually means people are spending less than they should, because the amount decreases each day. I fixed this by setting fixing the amount to spend each day at the beginning of the month.